### PR TITLE
Fix bugs to allow AT&T connection

### DIFF
--- a/swu_emulator.py
+++ b/swu_emulator.py
@@ -3424,11 +3424,17 @@ def read_res_ck_ik_2(reader_index,rand,autn):
 
 #https functions
 def https_imsi(server):
-    r = requests.get('https://' + server + '/?type=imsi', verify=False)
+    if not server.startswith('http'):
+        # Assume HTTPS if no protocol specified
+        server = 'https://' + server
+    r = requests.get(server + '/?type=imsi', verify=False)
     return r.json()['imsi']
 
 def https_res_ck_ik(server, rand, autn):
-    r = requests.get('https://' + server + '/?type=rand-autn&rand=' + rand + '&autn=' + autn, verify=False)
+    if not server.startswith('http'):
+        # Assume HTTPS if no protocol specified
+        server = 'https://' + server
+    r = requests.get(server + '/?type=rand-autn&rand=' + rand + '&autn=' + autn, verify=False)
     return r.json()['res'], r.json()['ck'], r.json()['ik']
 
 

--- a/swu_emulator.py
+++ b/swu_emulator.py
@@ -1881,8 +1881,8 @@ class swu():
         return return_list
 
     def set_sa_negotiated(self,num):
-        sa_negotiated = self.sa_list[num-1]
-        self.sa_list_negotiated = [self.sa_list[num-1]]
+        sa_negotiated = self.sa_list[num]
+        self.sa_list_negotiated = [self.sa_list[num]]
         
         #default values
         self.negotiated_integrity_algorithm = NONE
@@ -1909,9 +1909,9 @@ class swu():
         
 
     def set_sa_negotiated_child(self,num):
-        sa_negotiated = self.sa_list_child[num-1]
-        self.spi_init_child = self.sa_spi_list[num-1]
-        self.sa_list_negotiated_child = [self.sa_list_child[num-1]]
+        sa_negotiated = self.sa_list_child[num]
+        self.spi_init_child = self.sa_spi_list[num]
+        self.sa_list_negotiated_child = [self.sa_list_child[num]]
         
         #default values
         self.negotiated_integrity_algorithm_child = NONE

--- a/swu_emulator.py
+++ b/swu_emulator.py
@@ -3521,6 +3521,13 @@ def main():
        [PRF,PRF_HMAC_SHA1],
        [INTEG,AUTH_HMAC_SHA1_96],
        [D_H,MODP_1024_bit]  
+    ],
+    [
+       [IKE,0],
+       [ENCR,ENCR_AES_CBC,[KEY_LENGTH,256]],
+       [PRF,PRF_HMAC_SHA2_256],
+       [INTEG,AUTH_HMAC_SHA2_256_128],
+       [D_H,MODP_2048_bit] 
     ]
   
     ]


### PR DESCRIPTION
I managed to connect to AT&T's real VoWiFi ePDG and send packets, with just a few small bugfixes:
+ There seems to be an off-by-one error in SA negotiation [not sure how this works for other carriers?? someone else should investigate]
+ AT&T will only accept SHA2 proposals, so I added one
+ I used an Android app to provide the real EAP-AKA credentials from an eSIM, I didn't feel like implementing HTTPS so I implemented that too


<details>
  <summary>For anyone else trying to reproduce this:</summary>

I made a new Docker on Docker Desktop for Mac with plain Debian, then

```
sudo apt install -y python3-pip python3-setuptools python3-dev python3-pyscard libpcsclite-dev pcscd pcsc-tools net-tools iproute2
```

I used this `run.sh`:
```sh
python3 swu_emulator.py \
     --imsi=310280IMSIREDACTED \
     --dest=epdg.epc.mnc260.mcc310.pub.3gppnetwork.org \
     --modem=http://10.118.55.211:8080 \
     -M 310 -N 280 \
     -a ERESELLER
```
Where you need to replace the IMSI, and the modem with whatever you are using.
You can also change the APN, I'm using an MVNO and `ERESELLER` allows sending internet traffic... `IMS` is probably what you want for IMS stuff.

I created https://github.com/JJTech0130/EAPAKAClient, you can compile it with Android studio and install on an Android device with the desired SIM/eSIM

Note that you will need to grant it permission, e.g.
```
adb shell appops set --uid dev.jjtech.eapakaclient USE_ICC_AUTH_WITH_DEVICE_IDENTIFIER allow
```
</details>