### PR TITLE
Explicitly use 'fork' multiprocessing start method when running under non-macOS Unix

### DIFF
--- a/swu_emulator.py
+++ b/swu_emulator.py
@@ -3642,5 +3642,7 @@ def main():
     
     
 if __name__ == "__main__":
+    if os.name == 'posix' and sys.platform != 'darwin':
+        multiprocessing.set_start_method("fork")
     main()
     


### PR DESCRIPTION
Starting with Python 3.14, `forkserver` is now used by default on Unix-like systems instead of `fork` (Windows and macOS keep using `spawn`, see https://docs.python.org/3/whatsnew/3.14.html#multiprocessing). On my Arch system running Python 3.14.6 this results in multiple errors related to cryptography objects like `pn` and `dh_private_key`, since using `forkserver` requires them to be picklable, which they aren't because of being wrappers around C or Rust code. This commit explictly sets the default start method back to `fork` to avoid those problems (I tested it under Linux but the logic should work for BSDs, too). The ideal solution would be a (potentially major) refactor so that `self` isn't passed to workers and so there aren't any issues with `forkserver`, but I'm not sure the purported security benefits of using `forkserver` would outweigh the cons in this case.